### PR TITLE
Allow building with Xcode

### DIFF
--- a/Sources/Commands/main.swift
+++ b/Sources/Commands/main.swift
@@ -1,4 +1,5 @@
 import CommandsCore
+import Foundation
 
 let commands = Commands()
 


### PR DESCRIPTION
This fixes an import that was necessary for `localizedDescription` or `error`.