### PR TITLE
Make CommandExecutor better testable

### DIFF
--- a/Sources/CommandsCore/CommandExecutor.swift
+++ b/Sources/CommandsCore/CommandExecutor.swift
@@ -19,7 +19,7 @@ public class CommandExecutor {
         self.outputStream = outputStream
     }
 
-    public func executeCommand() {
+    public func execute() {
         let process = Process()
         process.launchPath = launchPath
         process.arguments = arguments

--- a/Sources/CommandsCore/CommandExecutor.swift
+++ b/Sources/CommandsCore/CommandExecutor.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class CommandExecutor {
 
-    let launchPath: String
-    let arguments: [String]
-    let outputStream: OutputStream
+    internal let launchPath: String
+    internal let arguments: [String]
+    internal let outputStream: OutputStream
 
     public init(launchPath: String, arguments: [String], outputStream: OutputStream = StandardOutOutputStream()) {
         self.launchPath = launchPath

--- a/Sources/CommandsCore/CommandExecutor.swift
+++ b/Sources/CommandsCore/CommandExecutor.swift
@@ -9,23 +9,25 @@ import Foundation
 
 public class CommandExecutor {
 
-    public init() {
+    let launchPath: String
+    let arguments: [String]
+    let outputStream: OutputStream
+
+    public init(launchPath: String, arguments: [String], outputStream: OutputStream = StandardOutOutputStream()) {
+        self.launchPath = launchPath
+        self.arguments = arguments
+        self.outputStream = outputStream
     }
 
-    public func executeCommand(at launchPath: String, arguments: [String]) {
-        let consoleStream = StandardOutOutputStream()
-        executeCommand(at: launchPath, arguments: arguments, outputStream: consoleStream)
-    }
-
-    public func executeCommand(at launchPath: String, arguments: [String], outputStream: OutputStream) {
+    public func executeCommand() {
         let process = Process()
         process.launchPath = launchPath
         process.arguments = arguments
         let pipe = Pipe()
         process.standardOutput = pipe
-        pipe.fileHandleForReading.readabilityHandler = { handle in
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            outputStream.write([UInt8](data), maxLength: data.count)
+            self?.outputStream.write([UInt8](data), maxLength: data.count)
         }
         process.launch()
         process.waitUntilExit()

--- a/Sources/CommandsCore/Commands.swift
+++ b/Sources/CommandsCore/Commands.swift
@@ -12,10 +12,9 @@ public final class Commands {
             throw Error.missingLaunchPath
         }
 
-        let commandExecutor = CommandExecutor()
         let launchPath = arguments[1]
-
-        commandExecutor.executeCommand(at: launchPath, arguments: forwardArguments())
+        let commandExecutor = CommandExecutor(launchPath: launchPath, arguments: forwardArguments())
+        commandExecutor.executeCommand()
     }
 
     internal func forwardArguments() -> [String] {

--- a/Sources/CommandsCore/Commands.swift
+++ b/Sources/CommandsCore/Commands.swift
@@ -14,7 +14,7 @@ public final class Commands {
 
         let launchPath = arguments[1]
         let commandExecutor = CommandExecutor(launchPath: launchPath, arguments: forwardArguments())
-        commandExecutor.executeCommand()
+        commandExecutor.execute()
     }
 
     internal func forwardArguments() -> [String] {

--- a/Tests/CommandsCoreTests/CommandExecutorTests.swift
+++ b/Tests/CommandsCoreTests/CommandExecutorTests.swift
@@ -6,13 +6,23 @@
 //
 
 import XCTest
-import CommandsCore
+@testable import CommandsCore
 
 class CommandExecutorTests: XCTestCase {
 
     func testCommandExecutorExecutes() {
         let commandExecutor = CommandExecutor(launchPath: "/bin/echo", arguments: ["hello world"])
         XCTAssertNoThrow(commandExecutor.executeCommand())
+    }
+
+    func testCommandExecutorLaunchpath() {
+        let commandExecutor = CommandExecutor(launchPath: "/bin/echo", arguments: [])
+        XCTAssertEqual(commandExecutor.launchPath, "/bin/echo")
+    }
+
+    func testCommandExecutorArguments() {
+        let commandExecutor = CommandExecutor(launchPath: "", arguments: ["hello world"])
+        XCTAssertEqual(commandExecutor.arguments, ["hello world"])
     }
 }
 

--- a/Tests/CommandsCoreTests/CommandExecutorTests.swift
+++ b/Tests/CommandsCoreTests/CommandExecutorTests.swift
@@ -12,7 +12,7 @@ class CommandExecutorTests: XCTestCase {
 
     func testCommandExecutorExecutes() {
         let commandExecutor = CommandExecutor(launchPath: "/bin/echo", arguments: ["hello world"])
-        XCTAssertNoThrow(commandExecutor.executeCommand())
+        XCTAssertNoThrow(commandExecutor.execute())
     }
 
     func testCommandExecutorLaunchpath() {

--- a/Tests/CommandsCoreTests/CommandExecutorTests.swift
+++ b/Tests/CommandsCoreTests/CommandExecutorTests.swift
@@ -11,8 +11,8 @@ import CommandsCore
 class CommandExecutorTests: XCTestCase {
 
     func testCommandExecutorExecutes() {
-        let commandExecutor = CommandExecutor()
-        XCTAssertNoThrow(commandExecutor.executeCommand(at: "/bin/echo", arguments: ["hello world"]))
+        let commandExecutor = CommandExecutor(launchPath: "/bin/echo", arguments: ["hello world"])
+        XCTAssertNoThrow(commandExecutor.executeCommand())
     }
 }
 

--- a/Tests/CommandsCoreTests/CommandTextOutputStreamTests.swift
+++ b/Tests/CommandsCoreTests/CommandTextOutputStreamTests.swift
@@ -15,8 +15,8 @@ class CommandTextOutputStreamTests: XCTestCase {
             XCTAssertEqual(text, "resillient koala\n")
         }
         if let scriptPath = "echo 'resillient koala' && exit".makeScript(for: type(of: self)) {
-            let commandExecutor = CommandExecutor()
-            commandExecutor.executeCommand(at: "/bin/sh", arguments: [scriptPath], outputStream: outputStream)
+            let commandExecutor = CommandExecutor(launchPath: "/bin/sh", arguments: [scriptPath], outputStream: outputStream)
+            commandExecutor.executeCommand()
         } else {
             XCTFail()
         }

--- a/Tests/CommandsCoreTests/CommandTextOutputStreamTests.swift
+++ b/Tests/CommandsCoreTests/CommandTextOutputStreamTests.swift
@@ -16,7 +16,7 @@ class CommandTextOutputStreamTests: XCTestCase {
         }
         if let scriptPath = "echo 'resillient koala' && exit".makeScript(for: type(of: self)) {
             let commandExecutor = CommandExecutor(launchPath: "/bin/sh", arguments: [scriptPath], outputStream: outputStream)
-            commandExecutor.executeCommand()
+            commandExecutor.execute()
         } else {
             XCTFail()
         }


### PR DESCRIPTION
Pass in parameters for command executor so that they can be injected in the tests.