### PR TITLE
Add support for standardError to standardOut output

### DIFF
--- a/Sources/CommandsCore/CommandExecutor.swift
+++ b/Sources/CommandsCore/CommandExecutor.swift
@@ -25,7 +25,10 @@ public class CommandExecutor {
         process.launchPath = launchPath
         process.arguments = arguments
 
-        process.standardOutput = outputStreamWritingPipe()
+        let pipe = outputStreamWritingPipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
         process.standardInput = inputPipe
 
         process.launch()


### PR DESCRIPTION
Pipes the standard error of a process to the output stream of a command executor. Fixes https://github.com/q231950/commands/issues/11